### PR TITLE
[BUG] CupertinoSearchTextField no enabled attribute in current version

### DIFF
--- a/lib/src/cupertino/cupertino_search.dart
+++ b/lib/src/cupertino/cupertino_search.dart
@@ -90,7 +90,6 @@ class _CupertinoSearchFlowTextFieldState
       child: CupertinoSearchTextField(
         focusNode: _focusNode,
         controller: widget.controller,
-        enabled: widget.enabled,
         onSubmitted: widget.onSubmitted,
         onChanged: widget.onSubmitted,
       ),


### PR DESCRIPTION
I am getting this error when building on iOS

<img width="1321" alt="Screen Shot 2021-10-06 at 16 32 54" src="https://user-images.githubusercontent.com/80730648/136177865-eda7a077-04cc-4ba7-b9b2-7cdd28703c82.png">


