### PR TITLE
Expose pressColor

### DIFF
--- a/lib/src/platform/platform_inkwell.dart
+++ b/lib/src/platform/platform_inkwell.dart
@@ -21,6 +21,7 @@ class PlatformInkWell extends StatelessWidget {
     this.customBorder,
     this.focusColor,
     this.hoverColor,
+    this.pressColor,
     this.highlightColor,
     this.overlayColor,
     this.splashColor,
@@ -173,6 +174,19 @@ class PlatformInkWell extends StatelessWidget {
   ///  * [splashFactory], which defines the appearance of the splash.
   final Color? hoverColor;
 
+  /// The color of the ink response when the parent widget is pressed.
+  ///
+  /// See also:
+  ///
+  ///  * [highlightShape], the shape of the focus, hover, and pressed
+  ///    highlights.
+  ///  * [highlightColor], the color of the pressed highlight.
+  ///  * [focusColor], the color of the focus highlight.
+  ///  * [hoverColor], the color of the hover highlight.
+  ///  * [splashColor], the color of the splash.
+  ///  * [splashFactory], which defines the appearance of the splash.
+  final Color? pressColor;
+
   /// The highlight color of the ink response when pressed. If this property is
   /// null then the highlight color of the theme, [ThemeData.highlightColor],
   /// will be used.
@@ -311,6 +325,7 @@ class PlatformInkWell extends StatelessWidget {
         mouseCursor: mouseCursor,
         focusColor: focusColor,
         hoverColor: hoverColor,
+        pressColor: pressColor ?? highlightColor,
         borderRadius: borderRadius,
         customBorder: customBorder,
         excludeFromSemantics: excludeFromSemantics,


### PR DESCRIPTION
Currently it is not possible to make tap effects visible on `PlatformInkwell` under iOS. This PR exposes `pressColor` from `CupertinoInkwell` to `PlatformInkwell`. 

I wasn't sure if it would be best just to assign `highlightColor` to it and call it a day. I opted instead for exposing `pressColor` but also assigning `highlightColor` to it if `pressColor` is null. Let me know your thoughts.