### PR TITLE
docs: update installation pub ver to newest ver

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Currently the following cupertino widgets are provided:
 Add this as a dependency to your `pubspec.yaml`:
 ```
 dependencies:
-  enough_platform_widgets: ^0.2.0
+  enough_platform_widgets: ^0.5.0
 ```
 
 The latest version or `enough_platform_widgets` is [![enough_platform_widgets version](https://img.shields.io/pub/v/enough_platform_widgets.svg)](https://pub.dartlang.org/packages/enough_platform_widgets).


### PR DESCRIPTION
As a developer, I want to see the newest version in pub.dev installation docs.