### PR TITLE
Fixed an issue on iOS time picker where the initial value is not returned

### DIFF
--- a/lib/src/platform/platform_time_picker.dart
+++ b/lib/src/platform/platform_time_picker.dart
@@ -142,8 +142,10 @@ Future<DateTime?> showPlatformSpecificDatePicker({
         ),
       ),
     );
-    if (result == true && pickedTime != null) {
-      return pickedTime;
+    if (result == true) {
+      return pickedTime != null
+          ? TimeOfDay.fromDateTime(pickedTime!)
+          : TimeOfDay.fromDateTime(initialDateTime);
     }
     return null;
   } else {


### PR DESCRIPTION
Fixed an issue on iOS time picker where the initial value is not returned on accept if value hasn't changed