### PR TITLE
fix: Material button icon autofocus for Flutter 3.41+

### DIFF
--- a/lib/src/platform/platform_filled_button_icon.dart
+++ b/lib/src/platform/platform_filled_button_icon.dart
@@ -44,7 +44,7 @@ class PlatformFilledButtonIcon extends StatelessWidget {
         style: style,
         focusNode: focusNode,
         clipBehavior: clipBehavior,
-        autofocus: autofocus,
+        autofocus: autofocus ?? false,
       ),
       cupertino: (context, platform) => CupertinoButton.filled(
         padding: EdgeInsets.all(8.0),

--- a/lib/src/platform/platform_text_button_icon.dart
+++ b/lib/src/platform/platform_text_button_icon.dart
@@ -44,7 +44,7 @@ class PlatformTextButtonIcon extends StatelessWidget {
         style: style,
         focusNode: focusNode,
         clipBehavior: clipBehavior,
-        autofocus: autofocus,
+        autofocus: autofocus ?? false,
       ),
       cupertino: (context, platform) => CupertinoButton(
         color: backgroundColor,


### PR DESCRIPTION
Fixes bool? vs bool for ElevatedButton.icon / TextButton.icon with current Flutter. Needed for Linux/desktop builds on Dart 3.11 / Flutter 3.41+.